### PR TITLE
Add support for changes to internal Docker networking.

### DIFF
--- a/run_demo
+++ b/run_demo
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
+
 function build() {
 	echo -e "\nBuilding dsc-chat-server image..."
 	docker build -t dsc-chat-server -f docker/server/Dockerfile ./chat-server
@@ -17,7 +20,7 @@ function up() {
 		# provided via APPLICATION_URL environment variable
 		export RUNMODE="docker"
 	elif [ -z "${PWD_HOST_FQDN}" ]; then
-		DOCKERHOST=`docker run --rm --net=host eclipse/che-ip`
+		export DOCKERHOST=$(getDockerHost)
 		export RUNMODE="docker"
 	else
 		PWD_HOST="${PWD_HOST_FQDN}"


### PR DESCRIPTION
- Networking changes introduced in Docker 4.1.x and forward on Windows and MAC stop the direct use of the internal docker host IP returned by the `docker run --rm --net=host eclipse/che-ip` process. On Windows and MAC `host.docker.internal` needs to be used for internal connections between containers on separate docker networks.
- `host.docker.internal` has been available on Windows and Mac since Docker Engine version 18.03 (March 2018). Support for `host.docker.internal` on Linux was introduced in version 20.10.0 (2020-12-08), but it does not run out of the box yet (as of Docker Engine 20.10.11 (2021-11-17)). You need to add `--add-host=host.docker.internal:host-gateway` to the `docker run` command in order for it to work.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>