### PR TITLE
Update proof configurations.

### DIFF
--- a/proof-configurations/pctf-chat/test/pctf-chat.json
+++ b/proof-configurations/pctf-chat/test/pctf-chat.json
@@ -22,6 +22,11 @@
             "issuer_did": "XZQpyaFa9hBUdJXfKHUvVg",
             "schema_name": "unverified_person",
             "schema_version": "0.1.0"
+          },
+          {
+            "issuer_did": "HTkhhCW1bAXWnxC1u3YVoa",
+            "schema_name": "unverified_person",
+            "schema_version": "0.1.0"
           }
         ]
       },
@@ -42,6 +47,11 @@
             "issuer_did": "XZQpyaFa9hBUdJXfKHUvVg",
             "schema_name": "unverified_person",
             "schema_version": "0.1.0"
+          },
+          {
+            "issuer_did": "HTkhhCW1bAXWnxC1u3YVoa",
+            "schema_name": "unverified_person",
+            "schema_version": "0.1.0"
           }
         ]
       },
@@ -60,6 +70,11 @@
           },
           {
             "issuer_did": "XZQpyaFa9hBUdJXfKHUvVg",
+            "schema_name": "unverified_person",
+            "schema_version": "0.1.0"
+          },
+          {
+            "issuer_did": "HTkhhCW1bAXWnxC1u3YVoa",
             "schema_name": "unverified_person",
             "schema_version": "0.1.0"
           }


### PR DESCRIPTION
- Add new CANdy DIDs as trusted issuers of the `unverified_person` credential.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>